### PR TITLE
Update node-config

### DIFF
--- a/cloud-config/node-config.yaml
+++ b/cloud-config/node-config.yaml
@@ -55,17 +55,8 @@ write_files:
       sudo modprobe ip6_tables
       sudo /home/core/calicoctl checksystem --fix
 
-      # Create a /tmp directory for docker plugins.  We don't actually use docker plugins, 
-      # but the default docker directory is in /usr, which fails on CoreOS.
-      TEMP_PLUGIN_DIR=`mktemp`
-      echo "Using tmp plugin dir ${TEMP_PLUGIN_DIR}"
-      
       # Start the Calico node. TODO: Use the --kubernetes flag when starting Calico node.
-      sudo /usr/bin/mkdir -p /etc/kubelet-plugins/calico
-      sudo /usr/bin/wget -N -P "/etc/kubelet-plugins/calico" "https://github.com/Metaswitch/calico-docker/releases/download/v0.5.1/calico_kubernetes"
-      sudo mv /etc/kubelet-plugins/calico/calico_kubernetes /etc/kubelet-plugins/calico/calico
-      sudo /usr/bin/chmod +x /etc/kubelet-plugins/calico/calico
-      sudo ETCD_AUTHORITY=$2 /home/core/calicoctl node --ip=$1 --plugin-dir=$TEMP_PLUGIN_DIR
+      sudo ETCD_AUTHORITY=$2 /home/core/calicoctl node --ip=$1 --kubernetes
 
 coreos:
   update:


### PR DESCRIPTION
Use the `calicoctl node --kubernetes` command instead of manually installing the plugin.
